### PR TITLE
Comments blade file support

### DIFF
--- a/app/Comments/Comments.php
+++ b/app/Comments/Comments.php
@@ -5,9 +5,8 @@ namespace FM\Comments;
 class Comments extends \Walker_Comment
 {
     // Wrapper for child comments list, starts the list before the elements are added.
-    public function startWrapper(&$output, $depth = 0, $args = [])
-    {
-        $GLOBALS['comment_depth'] = $depth + 2; ?>
+    public function start_lvl(&$output, $depth = 0, $args = [])
+    { ?>
 
         <ol class="children comments-list">
 
@@ -15,10 +14,8 @@ class Comments extends \Walker_Comment
     }
 
     // Closing wrapper for child comments list.
-    public function endWrapper(&$output, $depth = 0, $args = [])
-    {
-        $GLOBALS['comment_depth'] = $depth + 2;
-        ?>
+    public function end_lvl(&$output, $depth = 0, $args = [])
+    { ?>
 
         </ol><!-- .children -->
 
@@ -34,9 +31,9 @@ class Comments extends \Walker_Comment
      * @param int        $depth   Depth of the current comment.
      * @param array      $args    An array of arguments.
      */
-    public function startEl(&$output, $comment, $depth = 0, $args = [], $currentObjectId = 0)
+    public function start_el(&$output, $comment, $depth = 0, $args = [], $id = 0)
     {
-        ++$depth;
+        $depth++;
         $GLOBALS['comment_depth'] = $depth;
         $GLOBALS['comment'] = $comment;
 
@@ -47,13 +44,14 @@ class Comments extends \Walker_Comment
             $tag = 'article';
             $addBelow = 'comment';
         }
-        ?>
 
+        ob_start();
+        ?>
         <li <?php comment_class(empty($args['has_children']) ? '' : 'parent'); ?> id="comment-<?php comment_ID(); ?>" itemprop="comment" itemscope itemtype="http://schema.org/Comment">
             <article class="comment-body">
                 <footer class="comment-meta post-meta" role="complementary">
                     <h2 class="comment-author">
-                        <figure class="gravatar"><?php echo get_avatar($comment, 65, '', 'Author’s gravatar'); ?></figure>
+                        <figure class="gravatar"><?php echo get_avatar($comment, 65, '', 'Author\'s gravatar'); ?></figure>
                         <a class="comment-author-link" href="<?php comment_author_url(); ?>" itemprop="author"><?php comment_author(); ?></a>
                     </h2>
                     <a href="#comment-<?php comment_ID(); ?>">#</a> <time class="comment-meta-item" datetime="<?php comment_date('Y-m-d'); ?>T<?php comment_time('H:iP'); ?>" itemprop="datePublished"><?php comment_date('F jS Y'); ?></time>
@@ -80,5 +78,6 @@ class Comments extends \Walker_Comment
             </article>
         </li>
         <?php
+        $output .= ob_get_clean();
     }
 }

--- a/app/Templates/Provider.php
+++ b/app/Templates/Provider.php
@@ -16,6 +16,7 @@ class Provider
     public function __construct()
     {
         add_action('after_setup_theme', fn() => $this->init());
+        add_filter('comments_template', [$this, 'filterCommentsTemplate']);
     }
 
     public function render(string $template, array $data = []): void
@@ -30,6 +31,15 @@ class Provider
             : $this->factory->make($template, $data)->render();
     }
 
+    public function templateExists(string $template): bool
+    {
+        // Convert the dot notation (e.g., 'partials.comments') to a file path
+        $templatePath = fm()->config()->get('views.path') . '/' . str_replace('.', '/', $template) . '.blade.php';
+
+        // Check if the file exists
+        return file_exists($templatePath);
+    }
+
     private function init(): void
     {
         $compiler = new BladeCompiler(fm()->filesystem(), fm()->config()->get('cache.path'));
@@ -40,5 +50,30 @@ class Provider
         $resolver->register('blade', fn() => new CompilerEngine($compiler));
 
         $this->factory = new Factory($resolver, $finder, $dispatcher);
+    }
+
+    public function filterCommentsTemplate($file)
+    {
+        // Path to the Blade comments template
+        $bladeTemplate = 'partials.comments';
+
+        // Check if the Blade template exists
+        if ($this->templateExists($bladeTemplate)) {
+            // Render the Blade template
+            $this->render($bladeTemplate, [
+                'post' => get_post(),
+                'comments_open' => comments_open(),
+                'comments' => get_comments(['post_id' => get_the_ID()]),
+                'comment_pages' => paginate_comments_links(['echo' => false]),
+                'previous_page_url' => get_previous_comments_link(),
+                'next_page_url' => get_next_comments_link(),
+            ]);
+
+            // Return a blank file to prevent WordPress from rendering the default template
+            return FM_PATH . '/resources/views/index.php';
+        }
+
+        // If the Blade template doesn't exist, fall back to the default behavior
+        return $file;
     }
 }

--- a/resources/views/partials/comments.blade.php
+++ b/resources/views/partials/comments.blade.php
@@ -1,10 +1,8 @@
-<?
-if (post_password_required()) {
-  return;
-}
-?>
+@if(isset($post) && $post->password_required)
+    @return
+@endif
 
-<? if (comments_open()) { ?>
+@if(isset($comments_open) && $comments_open)
 <section id="comments" class="comments">
     <h2 class="comments-title">
         Responses
@@ -14,34 +12,34 @@ if (post_password_required()) {
         <a href="#respond">Write a new comment below</a>
     </div>
 
-    <? if (get_comments_number() != '0') { ?>
+    @if(have_comments())
     <ol class="comment-list">
-        <?
-        wp_list_comments(
-        [
+        {!! wp_list_comments([
             'style' => 'ol',
             'short_ping' => true,
             'avatar_size' => 64,
             'walker' => new FM\Comments\Comments()
-        ]
-        );
-    ?>
+        ]) !!}
     </ol><!-- .comment-list -->
-    <? } ?>
+    @endif
 
-    <? if (get_comment_pages_count() > 1 && get_option('page_comments')) { ?>
+    @if(get_comment_pages_count() > 1 && get_option('page_comments'))
     <nav aria-label="Comment">
         <ul class="pager">
-            <? if (get_previous_comments_link()) { ?>
-            <li class="previous"><? previous_comments_link(__('&larr; Older comments')) ?></li>
-            <? } ?>
-            <? if (get_next_comments_link()) { ?>
-            <li class="next"><? next_comments_link(__('Newer comments &rarr;')) ?></li>
-            <? } ?>
+            @if(isset($previous_page_url))
+            <li class="previous">
+                <a href="{{ $previous_page_url }}">&larr; Older comments</a>
+            </li>
+            @endif
+            @if(isset($next_page_url))
+            <li class="next">
+                <a href="{{ $next_page_url }}">Newer comments &rarr;</a>
+            </li>
+            @endif
         </ul>
     </nav>
-    <? } ?>
+    @endif
 
-    <? comment_form() ?>
+    {!! comment_form() !!}
 </section>
-<? } ?>
+@endif

--- a/resources/views/partials/content-single.blade.php
+++ b/resources/views/partials/content-single.blade.php
@@ -31,7 +31,7 @@
 </article>
 
 {!! get_the_post_navigation(['prev_text' => 'Older', 'next_text' => 'Newer']) !!}
-{!! comments_template('/views/partials/comments.blade.php') !!}
+{!! comments_template() !!}
 
 @section('sidebar')
   @include('partials.sidebar')


### PR DESCRIPTION
This PR adds support for using `comments.blade.php` as well as full `Walker_Comment` extends support.

1. Added a new filter for overriding the `comments_template()` WordPress function to support the blade file
2. Updated `Walker_Comment` extend to allow for deeper updating of internal commenting architecture
3. Updated `comments.blade.php` to use Blade syntax rather than plain PHP
4. No more need to point to specific PHP file in `comments_template()`